### PR TITLE
Dont pin the build version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,5 +2,3 @@
 plugins {
     id("com.gtnewhorizons.gtnhconvention")
 }
-
-version = "1.2"


### PR DESCRIPTION
The build version was pinned in the buildscript and therefore not pulled from the git tag.